### PR TITLE
feat: add yaml front matter support to posts using remark-frontmatter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,10 @@
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
         "remark": "~13.0.0",
-        "remark-html": "~13.0.1"
+        "remark-extract-frontmatter": "^3.1.0",
+        "remark-frontmatter": "^3.0.0",
+        "remark-html": "~13.0.1",
+        "yaml": "^2.0.0-3"
       },
       "devDependencies": {
         "@types/node": "^14.14.22",
@@ -4304,6 +4307,18 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -4425,6 +4440,14 @@
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/fragment-cache": {
@@ -5580,6 +5603,18 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-frontmatter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-0.2.0.tgz",
+      "integrity": "sha512-FHKL4w4S5fdt1KjJCwB0178WJ0evnyyQr5kXTM3wrOVpytD0hrkvd+AOOjU9Td8onOejCkmZ+HQRT3CZ3coHHQ==",
+      "dependencies": {
+        "micromark-extension-frontmatter": "^0.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-to-hast": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-10.2.0.tgz",
@@ -5683,6 +5718,18 @@
       "dependencies": {
         "debug": "^4.0.0",
         "parse-entities": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-frontmatter": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-0.2.2.tgz",
+      "integrity": "sha512-q6nPLFCMTLtfsctAuS0Xh4vaolxSFUWUWR6PZSrXXiRy+SANGllpcqdXFv2z07l0Xz/6Hl40hK0ffNCJPH2n1A==",
+      "dependencies": {
+        "fault": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromatch": {
@@ -7258,6 +7305,24 @@
         "remark-parse": "^9.0.0",
         "remark-stringify": "^9.0.0",
         "unified": "^9.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-extract-frontmatter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/remark-extract-frontmatter/-/remark-extract-frontmatter-3.1.0.tgz",
+      "integrity": "sha512-16TIAq0QTGs2GrbFi9azDxfcjwacf25W33h8zXAwiUbdW9lJN5KPaY6TZ7u2iSPTOSbIYBYmj9E0Q+8e+eGGPQ=="
+    },
+    "node_modules/remark-frontmatter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-3.0.0.tgz",
+      "integrity": "sha512-mSuDd3svCHs+2PyO29h7iijIZx4plX0fheacJcAoYAASfgzgVIcXGYSq9GFyYocFLftQs8IOmmkgtOovs6d4oA==",
+      "dependencies": {
+        "mdast-util-frontmatter": "^0.2.0",
+        "micromark-extension-frontmatter": "^0.2.0"
       },
       "funding": {
         "type": "opencollective",
@@ -9594,6 +9659,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yaml": {
+      "version": "2.0.0-3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-3.tgz",
+      "integrity": "sha512-gvtVaY+/mQ0OsXgaWy2Tf830JuXN7qEUYdXWsuiJVSkMRsBBQ90YVpQQofaURbhoA1xSbLBf7965oH6ddzNbBQ==",
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/zwitch": {
       "version": "1.0.5",
@@ -13196,6 +13269,14 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "requires": {
+        "format": "^0.2.0"
+      }
+    },
     "figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -13299,6 +13380,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -14144,6 +14230,14 @@
         "unist-util-stringify-position": "^2.0.0"
       }
     },
+    "mdast-util-frontmatter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-frontmatter/-/mdast-util-frontmatter-0.2.0.tgz",
+      "integrity": "sha512-FHKL4w4S5fdt1KjJCwB0178WJ0evnyyQr5kXTM3wrOVpytD0hrkvd+AOOjU9Td8onOejCkmZ+HQRT3CZ3coHHQ==",
+      "requires": {
+        "micromark-extension-frontmatter": "^0.2.0"
+      }
+    },
     "mdast-util-to-hast": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-10.2.0.tgz",
@@ -14227,6 +14321,14 @@
       "requires": {
         "debug": "^4.0.0",
         "parse-entities": "^2.0.0"
+      }
+    },
+    "micromark-extension-frontmatter": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-frontmatter/-/micromark-extension-frontmatter-0.2.2.tgz",
+      "integrity": "sha512-q6nPLFCMTLtfsctAuS0Xh4vaolxSFUWUWR6PZSrXXiRy+SANGllpcqdXFv2z07l0Xz/6Hl40hK0ffNCJPH2n1A==",
+      "requires": {
+        "fault": "^1.0.0"
       }
     },
     "micromatch": {
@@ -15519,6 +15621,20 @@
         "remark-parse": "^9.0.0",
         "remark-stringify": "^9.0.0",
         "unified": "^9.1.0"
+      }
+    },
+    "remark-extract-frontmatter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/remark-extract-frontmatter/-/remark-extract-frontmatter-3.1.0.tgz",
+      "integrity": "sha512-16TIAq0QTGs2GrbFi9azDxfcjwacf25W33h8zXAwiUbdW9lJN5KPaY6TZ7u2iSPTOSbIYBYmj9E0Q+8e+eGGPQ=="
+    },
+    "remark-frontmatter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/remark-frontmatter/-/remark-frontmatter-3.0.0.tgz",
+      "integrity": "sha512-mSuDd3svCHs+2PyO29h7iijIZx4plX0fheacJcAoYAASfgzgVIcXGYSq9GFyYocFLftQs8IOmmkgtOovs6d4oA==",
+      "requires": {
+        "mdast-util-frontmatter": "^0.2.0",
+        "micromark-extension-frontmatter": "^0.2.0"
       }
     },
     "remark-html": {
@@ -17313,6 +17429,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "yaml": {
+      "version": "2.0.0-3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-3.tgz",
+      "integrity": "sha512-gvtVaY+/mQ0OsXgaWy2Tf830JuXN7qEUYdXWsuiJVSkMRsBBQ90YVpQQofaURbhoA1xSbLBf7965oH6ddzNbBQ=="
     },
     "zwitch": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 4000",
     "build": "next build",
     "start": "next start"
   },
@@ -15,7 +15,10 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "remark": "~13.0.0",
-    "remark-html": "~13.0.1"
+    "remark-extract-frontmatter": "^3.1.0",
+    "remark-frontmatter": "^3.0.0",
+    "remark-html": "~13.0.1",
+    "yaml": "^2.0.0-3"
   },
   "devDependencies": {
     "@types/node": "^14.14.22",

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -1,9 +1,7 @@
 import { GetStaticPaths, GetStaticProps } from 'next';
 
-import { getPostContent } from '../../posts/getPostContent';
+import { getPost } from '../../posts/getPost';
 import { getPostSlugs } from '../../posts/getPostSlugs';
-
-type PostParams = { slug: string };
 
 function PostPage({ postContent }: { postContent: string }) {
   return <main dangerouslySetInnerHTML={{ __html: postContent }} />;
@@ -12,13 +10,13 @@ function PostPage({ postContent }: { postContent: string }) {
 export const getStaticProps: GetStaticProps = async ({
   params,
 }: {
-  params: PostParams;
+  params: PostPageParams;
 }) => {
-  const postContent = await getPostContent(params.slug);
+  const post = await getPost(params.slug);
 
   return {
     props: {
-      postContent,
+      postContent: post.content
     },
     revalidate: 5, // seconds
   };

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -3,8 +3,26 @@ import { GetStaticPaths, GetStaticProps } from 'next';
 import { getPost } from '../../posts/getPost';
 import { getPostSlugs } from '../../posts/getPostSlugs';
 
-function PostPage({ postContent }: { postContent: string }) {
-  return <main dangerouslySetInnerHTML={{ __html: postContent }} />;
+function PostPage({
+  postContent,
+  title,
+  date,
+}: {
+  postContent: string;
+  title: string;
+  date: string;
+}) {
+  return (
+    <main>
+      <article>
+        <header>
+          <h1>{title}</h1>
+          <p>{date}</p>
+        </header>
+        <div dangerouslySetInnerHTML={{ __html: postContent }} />
+      </article>
+    </main>
+  );
 }
 
 export const getStaticProps: GetStaticProps = async ({
@@ -16,7 +34,9 @@ export const getStaticProps: GetStaticProps = async ({
 
   return {
     props: {
-      postContent: post.content
+      postContent: post.content,
+      title: post.metadata.title,
+      date: post.metadata.createdDate,
     },
     revalidate: 5, // seconds
   };

--- a/posts/convertMarkdownToPost.ts
+++ b/posts/convertMarkdownToPost.ts
@@ -1,0 +1,50 @@
+import remark from 'remark';
+import html from 'remark-html';
+import frontmatter from 'remark-frontmatter';
+import extract from 'remark-extract-frontmatter';
+import YAML from 'yaml';
+
+async function convertMarkdownToPost(markdown: string): Promise<Post> {
+  const vFile = await parseMarkdownWithFrontmatter(markdown);
+
+  const { title, id, createdDate } = extractPostMetadata(vFile.data);
+
+  return {
+    content: vFile.toString(),
+    metadata: {
+      title,
+      id,
+      createdDate
+    },
+  };
+}
+
+/**
+ * @private
+ *
+ * parses md file and returns vFile
+ */
+function parseMarkdownWithFrontmatter(markdown: string) {
+  return remark()
+    .use(frontmatter, ['yaml'])
+    .use(extract, { yaml: YAML.parse })
+    .use(html)
+    .process(markdown);
+}
+
+/**
+ * @private
+ */
+function extractPostMetadata(data: any) {
+  const title = 'title' in data ? data.title : '';
+  const id = 'id' in data ? data.id : '';
+  const createdDate = 'createdDate' in data ? data.createdDate : '2020-02-20'; // Todo add sensible default
+
+  return {
+    title,
+    id,
+    createdDate,
+  };
+}
+
+export { convertMarkdownToPost };

--- a/posts/db/hello-world.md
+++ b/posts/db/hello-world.md
@@ -1,3 +1,9 @@
+---
+id: hello-world
+title: First post
+createdDate: 2020-02-19
+---
+
 # Hello world
 Super awesome post.
 
@@ -12,10 +18,13 @@ the release of Letraset sheets containing Lorem Ipsum passages, and more
 recently with desktop publishing software like Aldus PageMaker including
 versions of Lorem Ipsum.
 
+## Subtitle 2
+
 What would I like to write about here? I have no idea yeat.
 This is some test text to fine tune styling and see how it will look like...
 Test test test Lorem Ipsum testy test.
 
+### Subtitle 3
 Check this link: https://onet.pl
 
 

--- a/posts/getPost.ts
+++ b/posts/getPost.ts
@@ -2,24 +2,25 @@ import fs from 'fs';
 import { promisify } from 'util';
 import { postsBasePath } from "./consts";
 
-import transformMarkdownToHtml from './transformMarkdownToHtml';
+import { convertMarkdownToPost } from './convertMarkdownToPost';
 
 const readFile = promisify(fs.readFile);
 
 /**
  * Returns HTML-string markdown of an article found by slugname
  */
-async function getPostContent(slug: string): Promise<string | null> {
+async function getPost(slug: string): Promise<Post> {
   const filePath = `${postsBasePath}/${slug}.md`;
 
   try {
+    // @Todo wrap readFile() into some kind of Repository-ish object
     const fileData = await readFile(filePath, 'utf8');
 
-    return transformMarkdownToHtml(fileData);
+    return convertMarkdownToPost(fileData);
   } catch (err) {
     console.error(err);
     return null;
   }
 }
 
-export { getPostContent };
+export { getPost };

--- a/posts/transformMarkdownToHtml.ts
+++ b/posts/transformMarkdownToHtml.ts
@@ -1,7 +1,0 @@
-import remark from 'remark';
-import html from 'remark-html';
-
-export default async function transformMarkdownToHtml(markdown: string) {
-  const result = await remark().use(html).process(markdown);
-  return result.toString();
-}

--- a/posts/types.d.ts
+++ b/posts/types.d.ts
@@ -1,0 +1,5 @@
+type PostPageParams = { slug: string };
+
+type Post = { content: string; metadata: PostMetadata };
+
+type PostMetadata = { title: string; id: string; createdDate: string };


### PR DESCRIPTION
- add remark support for yaml front matter (damn I needed 2 plugins + yaml parser to get this working 😅 )
- rename some functions to better names
- standardise `Post` type + add some other types


TODO
- [x] use metadata in post page